### PR TITLE
Rename parameter label 'Dataiku Home Directory'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Version 1.3.1 - Minor release - 2024-01
+-  Change label for cache location parameter label for clarity
+
+
 ## Version 1.3.0 - Features release - 2023-06
 - Add python 3.7, 3.8, 3.9, 3.10, 3.11 support
 

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "id": "geocoder",
-    "version": "1.3.0",
+    "version": "1.3.1",
 
     "meta": {
         "label": "Geocoder",

--- a/plugin.json
+++ b/plugin.json
@@ -17,10 +17,11 @@
             "name": "cache_location",
             "type": "SELECT",
             "label": "Cache location",
+            "description": "The current user is the one running the recipe (if UIF is on) or DSS (else)",
             "selectChoices": [
             {
                 "value": "original",
-                "label": "Dataiku Data Directory"
+                "label": "Current User Home"
             },
             {
                 "value": "custom",

--- a/plugin.json
+++ b/plugin.json
@@ -17,7 +17,7 @@
             "name": "cache_location",
             "type": "SELECT",
             "label": "Cache location",
-            "description": "The current user is either the one running the recipe (in UIF setting ) or DSS (in non-UIF setting)",
+            "description": "The current user is either the one running the recipe (UIF installs ) or the one running DSS (non-UIF installs)",
             "selectChoices": [
             {
                 "value": "original",

--- a/plugin.json
+++ b/plugin.json
@@ -17,7 +17,7 @@
             "name": "cache_location",
             "type": "SELECT",
             "label": "Cache location",
-            "description": "The current user is the one running the recipe (if UIF is on) or DSS (else)",
+            "description": "The current user is either the one running the recipe (in UIF setting ) or DSS (in non-UIF setting)",
             "selectChoices": [
             {
                 "value": "original",


### PR DESCRIPTION
See the [shortcut ticket ](https://app.shortcut.com/dataiku/story/152337/rename-parameter-label-dataiku-home-directory-to-something-less-confusing).

The `Dataiku Data Directory`parameter has been renamed to `Current User Home`, and a description `"The current user is either the one running the recipe (in UIF setting ) or DSS (in non-UIF setting)"` has been added.